### PR TITLE
[FIXED JENKINS-28150] Fix optional dependency loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,20 +64,17 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>run-condition</artifactId>
             <version>1.0</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>email-ext</artifactId>
             <version>2.34</version>
-            <type>jar</type>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>build-timeout</artifactId>
             <version>1.12</version>
-            <type>jar</type>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/build_timeout/ConditionalTimeout.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/build_timeout/ConditionalTimeout.java
@@ -68,7 +68,7 @@ public class ConditionalTimeout implements Describable<ConditionalTimeout> {
         return DESCRIPTOR;
     }
     
-    @Extension
+    @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     
     public static class DescriptorImpl extends Descriptor<ConditionalTimeout> {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/build_timeout/RunConditionTimeoutStrategy.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/build_timeout/RunConditionTimeoutStrategy.java
@@ -89,7 +89,7 @@ public class RunConditionTimeoutStrategy extends BuildTimeOutStrategy  {
         return DESCRIPTOR;
     }
     
-    @Extension
+    @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     
     public static class DescriptorImpl extends BuildTimeOutStrategyDescriptor {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/mail_ext/RunConditionEmailTrigger.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/run_condition_extras/adapters/mail_ext/RunConditionEmailTrigger.java
@@ -76,7 +76,7 @@ public class RunConditionEmailTrigger extends EmailTrigger {
         return condition;
     }
     
-    @Extension
+    @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     @Override


### PR DESCRIPTION
The extensions here that are using an optional dependency's class must
be mark as optional. If not, we can see `ClassNotFoundException` when
Jenkins load this plugin.

Jira: [JENKINS-28150](https://issues.jenkins-ci.org/browse/JENKINS-28150)
